### PR TITLE
Fix eval submit button able to be spammed multiple times

### DIFF
--- a/frontend/src/pages/evaluate/EvaluateUserStation.jsx
+++ b/frontend/src/pages/evaluate/EvaluateUserStation.jsx
@@ -16,6 +16,7 @@ const EvaluateUserStation = ({ evaluator, evalStatus }) => {
   const [station, setStation] = useState(null);
   const [switchMap, setSwitchMap] = useState({});
   const [redirect, setRedirect] = useState(false);
+  const [disableButton, setDisableButton] = useState(false);
 
   useEffect(() => {
     getUser(uID).then((res) => setUser(res));
@@ -51,15 +52,20 @@ const EvaluateUserStation = ({ evaluator, evalStatus }) => {
         uID={uID}
         sID={sID}
         evalID={evaluator.userID}
+        setDisableButton={setDisableButton}
+        disableButton={disableButton}
       />
     </>
   );
 };
 
 const EvaluationForm = ({
-  station, switchMap, setSwitchMap, setRedirect, uID, sID, evalID,
+  station, switchMap, setSwitchMap, setRedirect, uID, sID, evalID, setDisableButton, disableButton,
 }) => (
-  <Form onSubmit={onSubmitEvaluation(uID, sID, evalID, switchMap, station.maxFailed, setRedirect)}>
+  <Form onSubmit={onSubmitEvaluation(uID, sID, evalID,
+    switchMap, station.maxFailed,
+    setRedirect, setDisableButton)}
+  >
     {station.groups.map((group) => (
       <Card key={group.groupID}>
         <Card.Header>{group.title}</Card.Header>
@@ -75,7 +81,7 @@ const EvaluationForm = ({
       </Card>
     ))}
     <br />
-    <Button className="edit-button" type="submit">
+    <Button className="edit-button" type="submit" disabled={disableButton}>
       Submit Evaluation
     </Button>
   </Form>
@@ -88,8 +94,9 @@ const changeSwitch = (id, switchMap, setSwitchMap) => () => {
 };
 
 const onSubmitEvaluation = (
-  uID, sID, evalID, switchMap, maxFailed, setRedirect,
+  uID, sID, evalID, switchMap, maxFailed, setRedirect, setDisableButton,
 ) => async (event) => {
+  setDisableButton(true);
   event.preventDefault();
   await submitEvaluation(uID, sID, evalID, switchMap, maxFailed);
   setRedirect(true);


### PR DESCRIPTION
Issue: Submit button would stay active after being pressed, allowing users with slow connections to submit the form multiple times.

Solution: Added a disableButton state that disables the button once pressed. Note how the button greys out after the initial click.

https://github.com/807-band/salsa/assets/85770026/a43e218c-0d6f-4bd3-a61f-a24302ad9d9c

