### PR TITLE
Update start-angular.sh to launch with port 443

### DIFF
--- a/attendance-frontend/start-angular.sh
+++ b/attendance-frontend/start-angular.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 cd ~/salsa/attendance-frontend/dist/client/browser
-npx serve -s . -l 444 \
+npx serve -s . -l 443 \
   --ssl-cert "/etc/letsencrypt/live/807.band/fullchain.pem" \
   --ssl-key "/etc/letsencrypt/live/807.band/privkey.pem"


### PR DESCRIPTION
Previously, we were serving on port 444 since the original 807.band frontend was on port 443. Since we're migrating to using this frontend for everything 807.band, we need to launch with port 443.