### PR TITLE
Small UI Bug Fix

### DIFF
--- a/attendance-frontend/src/app/station-packet-page/station-packet-page.component.html
+++ b/attendance-frontend/src/app/station-packet-page/station-packet-page.component.html
@@ -48,8 +48,7 @@
         <textarea [(ngModel)]="content"
                   name="content"
                   matInput
-                  cdkTextareaAutosize
-                  cdkAutosizeMinRows="3"
+                  style="min-height: 600px; resize: vertical;"
                   (keydown.tab)="insertTab($event)"></textarea>
       </mat-form-field>
 


### PR DESCRIPTION
In the station packet page, when editing parts of the content that have overflowed, the page was scrolling back to the top because of CdkTextareaAutosize