### PR TITLE
Bug fix 

### DIFF
--- a/attendance-frontend/src/app/main-layout/main-layout.component.html
+++ b/attendance-frontend/src/app/main-layout/main-layout.component.html
@@ -3,7 +3,7 @@
     <button mat-icon-button (click)="sidenav.toggle()"><mat-icon>menu</mat-icon></button>
     <a routerLink="/events" [queryParams]="{ type: 'upcoming' }" (click)="sidenav.toggle()">Upcoming Events</a>
     <a routerLink="/events" [queryParams]="{ type: 'recent' }" (click)="sidenav.toggle()">Recent Events</a>
-<!--    <a *ngIf="!sessionCacheService.isMember()" routerLink="/stations" (click)="sidenav.toggle()">Stations</a>-->
+    <a *ngIf="!sessionCacheService.isMember()" routerLink="/stations" (click)="sidenav.toggle()">Stations</a>
     <!--    <a routerLink="/events" [queryParams]="{ type: 'volunteer' }" *ngIf="sessionCacheService.isSectionLeader() || sessionCacheService.isOfficer()" (click)="sidenav.toggle()">Volunteer Sign-up</a>-->
 <!--    <a [href]="reactUrl">Stations</a>-->
     <!--    <a routerLink="/profile" (click)="sidenav.toggle()">Profile</a>-->

--- a/attendance-frontend/src/app/main-layout/main-layout.component.html
+++ b/attendance-frontend/src/app/main-layout/main-layout.component.html
@@ -3,7 +3,7 @@
     <button mat-icon-button (click)="sidenav.toggle()"><mat-icon>menu</mat-icon></button>
     <a routerLink="/events" [queryParams]="{ type: 'upcoming' }" (click)="sidenav.toggle()">Upcoming Events</a>
     <a routerLink="/events" [queryParams]="{ type: 'recent' }" (click)="sidenav.toggle()">Recent Events</a>
-    <a *ngIf="!sessionCacheService.isMember()" routerLink="/stations" (click)="sidenav.toggle()">Stations</a>
+<!--    <a *ngIf="!sessionCacheService.isMember()" routerLink="/stations" (click)="sidenav.toggle()">Stations</a>-->
     <!--    <a routerLink="/events" [queryParams]="{ type: 'volunteer' }" *ngIf="sessionCacheService.isSectionLeader() || sessionCacheService.isOfficer()" (click)="sidenav.toggle()">Volunteer Sign-up</a>-->
 <!--    <a [href]="reactUrl">Stations</a>-->
     <!--    <a routerLink="/profile" (click)="sidenav.toggle()">Profile</a>-->

--- a/backend-new/src/entities/evaluation-item.entity.ts
+++ b/backend-new/src/entities/evaluation-item.entity.ts
@@ -4,10 +4,10 @@ import {StationItem} from "./station-item.entity";
 
 @Entity('EvaluationItem')
 export class EvaluationItem {
-    @PrimaryColumn()
+    @PrimaryColumn({type: 'int'})
     evalId!: number;
 
-    @PrimaryColumn()
+    @PrimaryColumn({type: 'int'})
     itemId!: number;
 
     @ManyToOne(() => Evaluation, (evaluation: Evaluation) => evaluation.items, {


### PR DESCRIPTION
backend process kept crashing with this error from TypeOrm:

Column type for EvaluationItem#evalId is not defined and cannot be guessed. Make sure you have turned on an "emitDecoratorMetadata": true option in tsconfig.json. Also make sure you have imported "reflect-metadata" on top of the main entry file in your application (before any entity imported).If you are using JavaScript instead of TypeScript you must explicitly provide a column type.

I added a type decorator in the entity file for EvaluationItem